### PR TITLE
Fix admin user update failure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,10 @@ async function handleAdmin(request: Request, env: StartupAPIEnv, usersPath: stri
         const userId = parts[1];
         if (request.method === 'GET') return Response.json(await systemStub.getUser(userId));
         if (request.method === 'DELETE') return Response.json(await systemStub.deleteUser(userId));
+        if (request.method === 'PATCH' || request.method === 'PUT') {
+          const data = (await request.json()) as any;
+          return Response.json(await systemStub.updateUser(userId, data));
+        }
       }
       if (parts.length === 3 && parts[2] === 'memberships' && request.method === 'GET') {
         const userId = parts[1];

--- a/test/admin.spec.ts
+++ b/test/admin.spec.ts
@@ -416,6 +416,50 @@ describe('Admin Administration', () => {
     expect(Object.keys(profile).length).toBe(0);
   });
 
+  it('should update user profile via admin API', async () => {
+    // 1. Get an admin user
+    const adminId = env.USER.idFromName('admin');
+    const adminStub = env.USER.get(adminId);
+    const adminIdStr = adminId.toString();
+
+    const { sessionId } = await adminStub.createSession();
+    const cookieHeader = `session_id=${await cookieManager.encrypt(`${sessionId}:${adminIdStr}`)}`;
+
+    // 2. Create a user to update
+    const userId = env.USER.newUniqueId();
+    const userIdStr = userId.toString();
+    const systemStub = env.SYSTEM.get(env.SYSTEM.idFromName('global'));
+    await systemStub.registerUser({
+      id: userIdStr,
+      name: 'Original Name',
+      email: 'original@example.com',
+    });
+    const userStub = env.USER.get(userId);
+    await userStub.updateProfile({ name: 'Original Name', email: 'original@example.com' });
+
+    // 3. Update the user
+    const updatedName = 'Updated Name Admin';
+    const res = await SELF.fetch(`http://example.com/users/admin/api/users/${userIdStr}`, {
+      method: 'PATCH',
+      headers: {
+        Cookie: cookieHeader,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: updatedName }),
+    });
+
+    expect(res.status).toBe(200);
+
+    // 4. Verify in SystemDO index
+    const users = await systemStub.listUsers();
+    const updatedUser = users.find((u: any) => u.id === userIdStr);
+    expect(updatedUser.name).toBe(updatedName);
+
+    // 5. Verify in UserDO profile
+    const profile = await userStub.getProfile();
+    expect(profile.name).toBe(updatedName);
+  });
+
   it('should remove memberships from users when account is deleted', async () => {
     // 1. Get an admin user
     const adminId = env.USER.idFromName('admin');


### PR DESCRIPTION
This PR fixes a bug where updating a user's name or email from the admin panel failed because the backend route only supported GET and DELETE.

Changes:
- Added support for `PATCH` and `PUT` methods to the `/api/users/:userId` admin route.
- These methods now correctly call `systemStub.updateUser`, which updates both the `UserDO` profile and the `SystemDO` index.
- Added a regression test in `test/admin.spec.ts` to ensure user updates work as expected.

Closes #70

✨ Assisted by AI: Gemini