### PR TITLE
ci: use npm Trusted Publishing (OIDC) instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,11 @@ name: Publish
 # Publishes @startup-api/cloudflare to npm when a GitHub Release is published.
 # Create a release whose tag matches the package version (e.g. v0.0.1) — the
 # workflow verifies the two agree before publishing. Can also be run manually.
+#
+# Authentication uses npm Trusted Publishing (OIDC) — no NPM_TOKEN secret needed.
+# This requires a one-time setup on npmjs.com: the package's Settings → Trusted
+# Publisher → GitHub Actions, pointing at this repo and this workflow file
+# (publish.yml). Provenance is generated automatically.
 on:
   release:
     types: [published]
@@ -10,7 +15,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write # required for npm provenance
+  id-token: write # required for npm Trusted Publishing (OIDC) + provenance
 
 jobs:
   publish:
@@ -24,6 +29,10 @@ jobs:
           node-version: '20.x'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 20 ships npm 10.
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - run: npm ci
 
@@ -41,6 +50,4 @@ jobs:
           fi
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
## Summary

Switches the npm publish workflow to **Trusted Publishing (OIDC)** instead of a long-lived `NPM_TOKEN` secret.

The `v0.1.0` release ran but its publish step failed with `ENEEDAUTH` because no `NPM_TOKEN` secret was configured. Trusted Publishing removes the need for that secret entirely and generates provenance automatically.

## Changes
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step.
- Add an `npm install -g npm@latest` step (OIDC trusted publishing requires npm ≥ 11.5.1; Node 20 ships npm 10).
- Drop the explicit `--provenance` flag (provenance is automatic under trusted publishing).
- `id-token: write` permission was already present.

## Required one-time setup (done)
The package's **Trusted Publisher** is configured on npmjs.com for this repo + `publish.yml`.

## Publishing
After merge, trigger `gh workflow run publish.yml` (`workflow_dispatch` uses the default-branch workflow and skips the release tag/version check, publishing `0.1.0` from `package.json`). The existing `v0.1.0` GitHub release stays valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
