### PR TITLE
ci: upgrade GitHub Actions to latest (checkout/setup-node v6)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           cache: 'npm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           cache: 'npm'


### PR DESCRIPTION
Upgrades both workflow actions to their latest major versions:

- `actions/checkout` v4 → **v6** (6.0.3)
- `actions/setup-node` v4 → **v6** (6.4.0)

These majors run on Node 24, which clears the Node 20 runner-deprecation warning GitHub flagged on recent runs. Action inputs (`node-version`, `cache`, `registry-url`) are unchanged and compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)