### PR TITLE
feat(patreon): grant campaign owner access without entitlement check

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Configure an ordered list of rules (first match wins) mapping a path pattern to 
 - **`bypass`** — raw pass-through: no credential check, no identity resolution, no headers, no power-strip injection.
 - **`public`** — anyone; the session is resolved and identity/entitlement headers are forwarded when present.
 - **`authenticated`** — any logged-in user.
-- **`entitlement`** — a provider condition: Patreon `active_patron`, a specific `benefit` (perk) ID, or a `tier` ID.
+- **`entitlement`** — a provider condition: Patreon `active_patron`, a specific `benefit` (perk) ID, or a `tier` ID. The campaign owner is always granted (see below), since they have no membership to their own campaign.
 
 Patterns are exact (`/special`), prefix (`/app/*`), or `/` (homepage only). Each rule's `on_unauthorized` is `login` (redirect to sign in), `forbidden` (403), or `upgrade` (redirect to `upgrade_url`, e.g. a Patreon join page). When no policy is configured at all, every path is treated as `public` (backward compatible).
 
@@ -178,6 +178,14 @@ Entitlements are fetched once at login. Each provider can additionally opt into 
 
 Set `providers.patreon.campaignId` to disambiguate when a user belongs to multiple campaigns.
 
+#### Campaign owner
+
+A campaign's owner (creator) is not a patron of their own campaign, so they would fail every entitlement condition. Grant them access by listing their Patreon user id(s) in `providers.patreon.campaignOwnerId` (a string or array) — they then pass any Patreon `entitlement` rule without an entitlement check. Owners are also auto-detected when the identity response exposes their owned-campaign relationship (requires the `campaigns` scope and a matching `campaignId`); the explicit `campaignOwnerId` works without any extra scope.
+
+```ts
+patreon: { campaignOwnerId: '<OWNER_PATREON_USER_ID>' }
+```
+
 ### Configuring via the factory
 
 Environment variables hold only credentials/secrets and the per-deployment values (`ORIGIN_URL`, `AUTH_ORIGIN`, `USERS_PATH`, `ADMIN_IDS`, `ENVIRONMENT`). Everything else — provider scopes, Patreon campaign id, the access policy, and entitlement freshness — is passed to `createStartupAPI(config)`. The plain re-export still works with defaults:
@@ -196,6 +204,7 @@ const api = createStartupAPI({
     patreon: {
       scopes: 'identity.memberships',
       campaignId: '<CAMPAIGN_ID>',
+      campaignOwnerId: '<OWNER_PATREON_USER_ID>', // granted access without an entitlement check
       freshness: { ttl: true, cron: { schedule: '0 */6 * * *' }, webhook: true },
     },
   },

--- a/src/auth/PatreonProvider.ts
+++ b/src/auth/PatreonProvider.ts
@@ -7,6 +7,7 @@ import { parsePatreonIdentity } from '../entitlements/patreon';
 
 export class PatreonProvider extends OAuthProvider {
   private campaignId?: string;
+  private campaignOwnerIds: string[] = [];
 
   static create(env: StartupAPIEnv, redirectBase: string, options?: ProviderOptions): PatreonProvider | null {
     if (!env.PATREON_CLIENT_ID || !env.PATREON_CLIENT_SECRET) return null;
@@ -18,6 +19,8 @@ export class PatreonProvider extends OAuthProvider {
       options?.scopes,
     );
     provider.campaignId = options?.campaignId?.trim() || undefined;
+    const owners = options?.campaignOwnerId;
+    provider.campaignOwnerIds = (Array.isArray(owners) ? owners : owners ? [owners] : []).map((id) => id.trim()).filter(Boolean);
     return provider;
   }
 
@@ -119,6 +122,6 @@ export class PatreonProvider extends OAuthProvider {
       },
     });
 
-    return { patreon: parsePatreonIdentity(data, this.campaignId) };
+    return { patreon: parsePatreonIdentity(data, this.campaignId, this.campaignOwnerIds) };
   }
 }

--- a/src/entitlements/patreon.ts
+++ b/src/entitlements/patreon.ts
@@ -15,17 +15,31 @@ import type { PatreonEntitlement } from './types';
  *
  * When `campaignId` is provided, only the membership for that campaign is considered (a user may be a
  * patron of several campaigns through the same Patreon account); otherwise all memberships aggregate.
+ *
+ * `ownerIds` lists Patreon user ids that own the campaign being gated on. The campaign owner has no
+ * membership to their own campaign, so they are flagged `is_campaign_owner` (and later granted access
+ * regardless of the entitlement condition). Ownership is also auto-detected when the identity response
+ * exposes the user's owned-campaign relationship (requires the `campaigns` scope).
  */
-export function parsePatreonIdentity(json: any, campaignId?: string): PatreonEntitlement {
+export function parsePatreonIdentity(json: any, campaignId?: string, ownerIds: string[] = []): PatreonEntitlement {
   const empty: PatreonEntitlement = {
     patron_status: null,
     is_active_patron: false,
+    is_campaign_owner: false,
     entitled_tier_ids: [],
     entitled_benefit_ids: [],
     pledge_amount_cents: null,
   };
 
   if (!json || typeof json !== 'object' || !json.data) return empty;
+
+  // Campaign-owner detection: explicit owner id list, or the user's own campaign relationship
+  // (present only when the token has the `campaigns` scope) matching the gated campaign.
+  const userId = json.data.id != null ? String(json.data.id) : undefined;
+  const ownedCampaignId = json.data.relationships?.campaign?.data?.id;
+  const isCampaignOwner =
+    (userId != null && ownerIds.map(String).includes(userId)) ||
+    (ownedCampaignId != null && (!campaignId || String(ownedCampaignId) === String(campaignId)));
 
   // Index every included resource by `${type}:${id}` for O(1) ref resolution.
   const included = new Map<string, any>();
@@ -78,6 +92,7 @@ export function parsePatreonIdentity(json: any, campaignId?: string): PatreonEnt
   return {
     patron_status: patronStatus,
     is_active_patron: patronStatus === 'active_patron',
+    is_campaign_owner: isCampaignOwner,
     entitled_tier_ids: [...tierIds],
     entitled_benefit_ids: [...benefitIds],
     pledge_amount_cents: pledgeAmount,

--- a/src/entitlements/types.ts
+++ b/src/entitlements/types.ts
@@ -23,6 +23,12 @@ export interface PatreonEntitlement {
   patron_status: 'active_patron' | 'declined_patron' | 'former_patron' | null;
   /** Convenience flag derived from patron_status === 'active_patron'. */
   is_active_patron: boolean;
+  /**
+   * Whether this user is the owner (creator) of the campaign being gated on. Campaign owners have no
+   * membership to their own campaign, so they would fail patron/benefit/tier checks; the entitlement
+   * checker grants them access regardless of the configured condition.
+   */
+  is_campaign_owner: boolean;
   /** IDs of tiers the user is currently entitled to. */
   entitled_tier_ids: string[];
   /** IDs of benefits (perks) granted by the currently-entitled tiers (deduped). */

--- a/src/policy/entitlementCheckers.ts
+++ b/src/policy/entitlementCheckers.ts
@@ -18,6 +18,8 @@ export const providerEntitlementCheckers: Record<string, EntitlementChecker> = {
   patreon(condition, entitlements) {
     const patreon = entitlements?.patreon;
     if (!patreon) return false;
+    // The campaign owner has no membership to their own campaign — grant access regardless of condition.
+    if (patreon.is_campaign_owner) return true;
     switch (condition.type) {
       case 'active_patron':
         return patreon.is_active_patron;

--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -28,6 +28,8 @@ export const ProviderOptionsSchema = z.object({
   scopes: z.union([z.string(), z.array(z.string())]).optional(),
   /** Patreon only: restrict entitlements to a single campaign id. */
   campaignId: z.string().optional(),
+  /** Patreon only: user id(s) of the campaign owner(s), granted access without an entitlement check. */
+  campaignOwnerId: z.union([z.string(), z.array(z.string())]).optional(),
   freshness: ProviderFreshnessSchema.optional(),
 });
 

--- a/src/schemas/entitlement.ts
+++ b/src/schemas/entitlement.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 export const PatreonEntitlementSchema = z.object({
   patron_status: z.enum(['active_patron', 'declined_patron', 'former_patron']).nullable(),
   is_active_patron: z.boolean(),
+  is_campaign_owner: z.boolean(),
   entitled_tier_ids: z.array(z.string()),
   entitled_benefit_ids: z.array(z.string()),
   pledge_amount_cents: z.number().nullable(),

--- a/test/entitlement_integration.spec.ts
+++ b/test/entitlement_integration.spec.ts
@@ -34,7 +34,7 @@ function fetchWith(path: string, cookie?: string) {
   });
 }
 
-async function createPatreonUser(benefits: string[], active = true) {
+async function createPatreonUser(benefits: string[], active = true, isOwner = false) {
   const userId = env.USER.newUniqueId();
   const userStub = env.USER.get(userId);
   const userIdStr = userId.toString();
@@ -51,6 +51,7 @@ async function createPatreonUser(benefits: string[], active = true) {
     patreon: {
       patron_status: active ? 'active_patron' : 'former_patron',
       is_active_patron: active,
+      is_campaign_owner: isOwner,
       entitled_tier_ids: ['t1'],
       entitled_benefit_ids: benefits,
       pledge_amount_cents: 500,
@@ -116,6 +117,17 @@ describe('Entitlement headers + access policy', () => {
   it('forbids a gated path for an unauthenticated request', async () => {
     const res = await fetchWith('/special');
     expect(res.status).toBe(403);
+  });
+
+  it('allows the campaign owner on a gated path even without the benefit', async () => {
+    const cookie = await createPatreonUser([], false, /* isOwner */ true);
+    const fetchSpy = spyOrigin();
+    try {
+      const res = await fetchWith('/special', cookie);
+      expect(res.status).toBe(200);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it('bypass path forwards with NO X-StartupAPI headers and no power-strip injection, even when logged in', async () => {

--- a/test/entitlement_parse.spec.ts
+++ b/test/entitlement_parse.spec.ts
@@ -48,10 +48,30 @@ describe('parsePatreonIdentity', () => {
     expect(result).toEqual({
       patron_status: null,
       is_active_patron: false,
+      is_campaign_owner: false,
       entitled_tier_ids: [],
       entitled_benefit_ids: [],
       pledge_amount_cents: null,
     });
+  });
+
+  it('flags the campaign owner when their user id is in the configured owner list', () => {
+    // identity() builds data.id = 'user-1'.
+    const result = parsePatreonIdentity(identity(null, []), undefined, ['user-1']);
+    expect(result.is_campaign_owner).toBe(true);
+  });
+
+  it('auto-detects the campaign owner from the owned-campaign relationship', () => {
+    const json = identity(null, []);
+    json.data.relationships = { ...json.data.relationships, campaign: { data: { type: 'campaign', id: 'camp-1' } } };
+    expect(parsePatreonIdentity(json, 'camp-1').is_campaign_owner).toBe(true);
+    // A different gated campaign id does not match.
+    expect(parsePatreonIdentity(json, 'other-camp').is_campaign_owner).toBe(false);
+  });
+
+  it('does not flag a non-owner', () => {
+    const result = parsePatreonIdentity(identity('active_patron', [{ id: 't1', benefits: ['b1'] }]), undefined, ['someone-else']);
+    expect(result.is_campaign_owner).toBe(false);
   });
 
   it('marks a declined patron as not active', () => {

--- a/test/policy.spec.ts
+++ b/test/policy.spec.ts
@@ -3,13 +3,14 @@ import { AccessPolicy, evaluateAccess, matchPattern } from '../src/policy/access
 import type { AccessRule } from '../src/schemas/policy';
 import type { Entitlements } from '../src/entitlements/types';
 
-const patreonEntitlements = (benefits: string[], active = true): Entitlements => ({
+const patreonEntitlements = (benefits: string[], active = true, isOwner = false): Entitlements => ({
   provider: 'patreon',
   checked_at: 0,
   source: 'oauth',
   patreon: {
     patron_status: active ? 'active_patron' : 'former_patron',
     is_active_patron: active,
+    is_campaign_owner: isOwner,
     entitled_tier_ids: ['t1'],
     entitled_benefit_ids: benefits,
     pledge_amount_cents: 500,
@@ -57,6 +58,15 @@ describe('evaluateAccess', () => {
     expect(evaluateAccess(r, { authenticated: true, entitlements: patreonEntitlements(['vip']) }).allow).toBe(true);
     const denied = evaluateAccess(r, { authenticated: true, entitlements: patreonEntitlements(['other']) });
     expect(denied).toMatchObject({ allow: false, reason: 'not_entitled', action: 'upgrade' });
+  });
+
+  it('grants the campaign owner regardless of the condition', () => {
+    const benefit = rule({ mode: 'entitlement', provider: 'patreon', condition: { type: 'benefit', benefit_id: 'vip' } }, 'forbidden');
+    const tier = rule({ mode: 'entitlement', provider: 'patreon', condition: { type: 'tier', tier_id: 'nope' } }, 'forbidden');
+    // Owner has no benefits/tiers/active status, but is the campaign owner.
+    const owner = patreonEntitlements([], false, true);
+    expect(evaluateAccess(benefit, { authenticated: true, entitlements: owner }).allow).toBe(true);
+    expect(evaluateAccess(tier, { authenticated: true, entitlements: owner }).allow).toBe(true);
   });
 
   it('denies an entitlement requirement when not authenticated', () => {


### PR DESCRIPTION
## Summary

For the Patreon module, grant the **campaign owner** access without checking entitlements. A campaign's owner (creator) has no membership to their own campaign, so they would fail every entitlement condition (`active_patron` / `benefit` / `tier`) and be locked out of gated paths.

## Changes
- New `providers.patreon.campaignOwnerId` config (string or array) — Patreon user id(s) of the campaign owner(s). No extra OAuth scope required.
- `PatreonEntitlement` gains `is_campaign_owner`; the Patreon entitlement checker short-circuits to **grant** when it's set, before evaluating the configured condition.
- `parsePatreonIdentity` flags ownership when the user's id is in the configured owner list, or (best-effort) when the identity response exposes the user's owned-campaign relationship matching `campaignId` (requires the `campaigns` scope).
- Docs updated; example config includes `campaignOwnerId`.

## Tests
- **106 tests pass** (5 new), `eslint` + `tsc` clean.
- New coverage: owner detection via config list and via the owned-campaign relationship, non-owner stays false, `evaluateAccess` grants the owner regardless of `benefit`/`tier`, and an end-to-end gated-path test where the owner is allowed without the required benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
