### PR TITLE
Bypass access policy gate for admin users

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Configure an ordered list of rules (first match wins) mapping a path pattern to 
 
 Patterns are exact (`/special`), prefix (`/app/*`), or `/` (homepage only). Each rule's `on_unauthorized` is `login` (redirect to sign in), `forbidden` (403), or `upgrade` (redirect to `upgrade_url`, e.g. a Patreon join page). When no policy is configured at all, every path is treated as `public` (backward compatible).
 
+Admin users (those listed in `ADMIN_IDS`) bypass every `authenticated`/`entitlement` requirement and can reach any gated path. Their identity is still resolved and the usual identity/entitlement headers are forwarded to the origin — only the gate itself is skipped. (`bypass` paths remain a raw pass-through for everyone, with no identity resolution.)
+
 The policy is passed to the factory as `accessPolicy` (see below). Example:
 
 ```ts

--- a/src/createStartupAPI.ts
+++ b/src/createStartupAPI.ts
@@ -7,7 +7,7 @@ import { CredentialDO } from './storage/CredentialDO';
 import { CookieManager } from './CookieManager';
 import { initPlans } from './billing/plansConfig';
 import { Plan } from './billing/Plan';
-import { getActiveProviders, parseCookies, getUserFromSession } from './handlers/utils';
+import { getActiveProviders, parseCookies, getUserFromSession, isAdmin } from './handlers/utils';
 import { handleAdmin } from './handlers/admin';
 import {
   handleMe,
@@ -259,6 +259,7 @@ export function createStartupAPI(config: StartupAPIConfig = {}) {
 
       const user = await getUserFromSession(request, env, cookieManager);
       const authenticated = !!user;
+      const userIsAdmin = user ? isAdmin(user, env) : false;
       let entitlements: Entitlements | null = null;
       let loginProvider: string | undefined;
 
@@ -294,8 +295,8 @@ export function createStartupAPI(config: StartupAPIConfig = {}) {
         newRequest.headers.set(key, value);
       }
 
-      // Enforce the requirement.
-      const decision = evaluateAccess(rule, { authenticated, entitlements });
+      // Enforce the requirement. Admins bypass the gate (identity/headers above still apply).
+      const decision = evaluateAccess(rule, { authenticated, entitlements, isAdmin: userIsAdmin });
       if (!decision.allow) {
         return denyResponse(decision, { usersPath, returnUrl, activeProviders: getActiveProviders(env) });
       }

--- a/src/policy/accessPolicy.ts
+++ b/src/policy/accessPolicy.ts
@@ -30,8 +30,15 @@ function deny(reason: 'unauthenticated' | 'not_entitled', rule: AccessRule): Pol
  * Decide whether a request satisfies a resolved rule, given the auth state and resolved entitlements.
  * `bypass`/`public` always allow; `authenticated` needs a logged-in user; `entitlement` dispatches the
  * condition through the provider checker registry.
+ *
+ * Admin users (`ctx.isAdmin`) bypass every requirement: identity has already been resolved and headers
+ * forwarded by the time we get here, but the gate itself is skipped so admins can reach any gated path.
  */
-export function evaluateAccess(rule: AccessRule, ctx: { authenticated: boolean; entitlements: Entitlements | null }): PolicyDecision {
+export function evaluateAccess(
+  rule: AccessRule,
+  ctx: { authenticated: boolean; entitlements: Entitlements | null; isAdmin?: boolean },
+): PolicyDecision {
+  if (ctx.isAdmin) return { allow: true };
   const req = rule.requirement;
   switch (req.mode) {
     case 'bypass':

--- a/test/entitlement_integration.spec.ts
+++ b/test/entitlement_integration.spec.ts
@@ -34,8 +34,7 @@ function fetchWith(path: string, cookie?: string) {
   });
 }
 
-async function createPatreonUser(benefits: string[], active = true) {
-  const userId = env.USER.newUniqueId();
+async function createPatreonUser(benefits: string[], active = true, userId = env.USER.newUniqueId()) {
   const userStub = env.USER.get(userId);
   const userIdStr = userId.toString();
   const subjectId = 'patreon-' + userIdStr.slice(0, 10);
@@ -116,6 +115,22 @@ describe('Entitlement headers + access policy', () => {
   it('forbids a gated path for an unauthenticated request', async () => {
     const res = await fetchWith('/special');
     expect(res.status).toBe(403);
+  });
+
+  it('lets an admin reach a gated path even without the required benefit', async () => {
+    // ADMIN_IDS is "admin" in the test env; in test mode isAdmin() resolves names via idFromName().
+    const cookie = await createPatreonUser(['some-other-benefit'], true, env.USER.idFromName('admin'));
+    const fetchSpy = spyOrigin();
+    try {
+      const res = await fetchWith('/special', cookie);
+      expect(res.status).toBe(200);
+
+      // Identity is still resolved and headers forwarded — only the gate is bypassed.
+      const out = fetchSpy.mock.calls.at(-1)![0] as Request;
+      expect(out.headers.get('X-StartupAPI-Authenticated')).toBe('true');
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it('bypass path forwards with NO X-StartupAPI headers and no power-strip injection, even when logged in', async () => {

--- a/test/policy.spec.ts
+++ b/test/policy.spec.ts
@@ -63,6 +63,14 @@ describe('evaluateAccess', () => {
     const r = rule({ mode: 'entitlement', provider: 'patreon', condition: { type: 'active_patron' } });
     expect(evaluateAccess(r, { authenticated: false, entitlements: null })).toMatchObject({ reason: 'unauthenticated' });
   });
+
+  it('lets admins bypass any requirement', () => {
+    const authRule = rule({ mode: 'authenticated' }, 'login');
+    expect(evaluateAccess(authRule, { authenticated: false, entitlements: null, isAdmin: true }).allow).toBe(true);
+
+    const entRule = rule({ mode: 'entitlement', provider: 'patreon', condition: { type: 'benefit', benefit_id: 'vip' } }, 'upgrade');
+    expect(evaluateAccess(entRule, { authenticated: true, entitlements: patreonEntitlements(['other']), isAdmin: true }).allow).toBe(true);
+  });
 });
 
 describe('AccessPolicy', () => {


### PR DESCRIPTION
## What & why

Admin users (those listed in `ADMIN_IDS`) now bypass every `authenticated`/`entitlement` access-policy requirement and can reach any gated path. Their identity is still resolved and the usual identity/entitlement headers are forwarded to the origin — only the requirement gate itself is skipped.

## Changes

- **`src/policy/accessPolicy.ts`** — `evaluateAccess` takes an optional `isAdmin` in its context and short-circuits to `{ allow: true }` before any requirement check.
- **`src/createStartupAPI.ts`** — computes `isAdmin(user, env)` from the resolved session user and passes it into `evaluateAccess`. This happens **after** identity resolution and header forwarding, so admins still get `X-StartupAPI-*` headers sent to the origin. The pre-identity `bypass` requirement mode (raw pass-through) is unchanged.
- **`README.md`** — documents the admin-bypass behavior in the access-policy section.

## Tests

- `test/policy.spec.ts` — unit test: an admin bypasses `authenticated` and an unmet `entitlement` requirement.
- `test/entitlement_integration.spec.ts` — end-to-end: an admin without the required Patreon benefit still gets `200` on a gated path, with identity headers still forwarded.

`tsc --noEmit` and ESLint are clean; new tests pass.

## Note on scope

This grants admins access to **every** gated path globally. If per-rule / configurable opt-in is preferred, that can be a follow-up.

https://claude.ai/code/session_019t5EXqDTxJxLuNAg31VbXm

---
_Generated by [Claude Code](https://claude.ai/code/session_019t5EXqDTxJxLuNAg31VbXm)_