### PR TITLE
Allow authors to place their own <power-strip> for custom placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ const api = createStartupAPI({
 3. **Proxying:** All other requests are proxied to the configured `ORIGIN_URL`
 4. **Injection:** For `text/html` responses, the worker injects a `<script>` tag and a `<power-strip>` custom element before serving the content to the user
 
+### Customizing the power strip
+
+By default the worker injects its own `<power-strip>` pinned to the top-right corner of the page. If that overlaps your own menu or you simply want it somewhere else, **place a `<power-strip>` element in your own HTML**. When the worker sees one, it injects only `power-strip.js` (which defines the custom element) and leaves your element exactly where you put it — so you control placement and styling:
+
+```html
+<nav>
+  <!-- ...your links... -->
+  <power-strip></power-strip>
+</nav>
+```
+
+- **`providers` is optional.** If you omit it, the worker fills in the active providers for you (e.g. `providers="google,twitch,patreon"`). Set it yourself to override which login buttons appear.
+- **Prefer an explicit closing tag.** `<power-strip></power-strip>` and `<power-strip/>` are both detected, but per the HTML spec `<power-strip/>` is *not* truly self-closing — the browser treats it as an open tag and nests the following content inside it. Use a closing tag (or place the element last in its container) to avoid surprises.
+- **Script-only opt-out.** Use `<power-strip hidden>` to load `power-strip.js` (and its JS API) without rendering a visible strip.
+
 ## Access policy & provider entitlements
 
 StartupAPI can gate access to paths and forward the visitor's login/entitlement status to your origin so it can render gated UI. This is **provider-agnostic infrastructure**; only Patreon currently implements perk-level (benefit/tier) checks — Google and Twitch participate at the login levels only.

--- a/public/users/power-strip.js
+++ b/public/users/power-strip.js
@@ -252,7 +252,14 @@ class PowerStrip extends HTMLElement {
           display: block;
           font-family: system-ui, -apple-system, sans-serif;
         }
-        
+
+        /* Honor the native [hidden] attribute so authors can load the script
+           without rendering a visible strip (<power-strip hidden>). The :host
+           rule above would otherwise override the UA [hidden] { display: none }. */
+        :host([hidden]) {
+          display: none !important;
+        }
+
         @keyframes fadeIn {
           from { opacity: 0; }
           to { opacity: 1; }

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -75,5 +75,5 @@ Users can be members of multiple accounts.
 
 ## Frontend & Integration
 
-- **Power Strip**: A custom element (`<power-strip>`) injected into proxied HTML pages. It provides a consistent UI for login, account switching, and profile management.
+- **Power Strip**: A custom element (`<power-strip>`) injected into proxied HTML pages. It provides a consistent UI for login, account switching, and profile management. Authors can place their own `<power-strip>` element to control its placement/styling; in that case the worker injects only `power-strip.js` and leaves the element alone (auto-filling `providers` if omitted, honoring `hidden` for a script-only opt-out).
 - **API Proxy**: The worker acts as a proxy, intercepting `/users/` paths for system features while forwarding other requests to the configured `ORIGIN_URL`.

--- a/src/PowerStrip.ts
+++ b/src/PowerStrip.ts
@@ -2,18 +2,42 @@ export async function injectPowerStrip(response: Response, usersPath: string, pr
   const contentType = response.headers.get('Content-Type');
 
   if (contentType && contentType.includes('text/html')) {
-    // Inject a script tag and a custom element into the proxied HTML pages.
-    // The script is loaded from the USERS_PATH, which is intercepted by this worker.
+    const providersAttr = providers.join(',');
+
+    // Track whether the page author placed their own <power-strip> element.
+    // If they did, we respect their placement/styling and only load the script.
+    let hasUserPowerStrip = false;
+
     return new HTMLRewriter()
+      .on('power-strip', {
+        element(element) {
+          hasUserPowerStrip = true;
+
+          // Fill in the active providers for the author so their element works
+          // out of the box, unless they explicitly chose their own list.
+          if (!element.hasAttribute('providers')) {
+            element.setAttribute('providers', providersAttr);
+          }
+        },
+      })
       .on('body', {
         element(element) {
-          element.prepend(
-            `<script src="${usersPath}power-strip.js" async></script>` +
-              `<power-strip providers="${providers.join(',')}" style="position: absolute; top: 0; right: 0; z-index: 9999; padding: 0.1rem; border-radius: 0 0 0 0.3rem;">` +
-              '<svg viewBox="0 0 24 24" style="width: 1rem; height: 1rem;"><path d="M7 2v11h3v9l7-12h-4l4-8z"/></svg>' +
-              '</power-strip>',
-            { html: true },
-          );
+          // The script is always needed to define the <power-strip> custom element.
+          // It is loaded from the USERS_PATH, which is intercepted by this worker.
+          element.prepend(`<script src="${usersPath}power-strip.js" async></script>`, { html: true });
+
+          // Defer the component decision until the end of <body>, by which point
+          // the streaming parser has seen any author-supplied <power-strip>.
+          element.onEndTag((end) => {
+            if (!hasUserPowerStrip) {
+              end.before(
+                `<power-strip providers="${providersAttr}" style="position: absolute; top: 0; right: 0; z-index: 9999; padding: 0.1rem; border-radius: 0 0 0 0.3rem;">` +
+                  '<svg viewBox="0 0 24 24" style="width: 1rem; height: 1rem;"><path d="M7 2v11h3v9l7-12h-4l4-8z"/></svg>' +
+                  '</power-strip>',
+                { html: true },
+              );
+            }
+          });
         },
       })
       .transform(response);

--- a/test/powerstrip.spec.ts
+++ b/test/powerstrip.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { injectPowerStrip } from '../src/PowerStrip';
+
+const USERS_PATH = '/users/';
+const PROVIDERS = ['google', 'twitch', 'patreon'];
+
+function htmlResponse(body: string): Response {
+  return new Response(body, { headers: { 'Content-Type': 'text/html' } });
+}
+
+// The distinctive inline style only the worker's *default* strip carries.
+const DEFAULT_STRIP_STYLE = 'position: absolute; top: 0; right: 0';
+
+// Count occurrences of the opening tag of a <power-strip> element.
+function countPowerStrips(html: string): number {
+  return (html.match(/<power-strip[\s/>]/g) || []).length;
+}
+
+describe('injectPowerStrip', () => {
+  it('injects the script and a default strip when the page has no power-strip', async () => {
+    const res = await injectPowerStrip(htmlResponse('<html><body><h1>Hi</h1></body></html>'), USERS_PATH, PROVIDERS);
+    const html = await res.text();
+
+    expect(html).toContain(`<script src="${USERS_PATH}power-strip.js" async></script>`);
+    expect(html).toContain(DEFAULT_STRIP_STYLE);
+    expect(html).toContain('<power-strip providers="google,twitch,patreon"');
+    expect(countPowerStrips(html)).toBe(1);
+  });
+
+  it('injects only the script when the author placed their own <power-strip>', async () => {
+    const res = await injectPowerStrip(
+      htmlResponse('<html><body><nav><power-strip></power-strip></nav></body></html>'),
+      USERS_PATH,
+      PROVIDERS,
+    );
+    const html = await res.text();
+
+    expect(html).toContain(`<script src="${USERS_PATH}power-strip.js" async></script>`);
+    // No default strip appended, and the author's element is left in place.
+    expect(html).not.toContain(DEFAULT_STRIP_STYLE);
+    expect(countPowerStrips(html)).toBe(1);
+    expect(html).toContain('<nav><power-strip');
+  });
+
+  it('auto-fills the providers attribute on a bare author element', async () => {
+    const res = await injectPowerStrip(
+      htmlResponse('<html><body><power-strip></power-strip></body></html>'),
+      USERS_PATH,
+      PROVIDERS,
+    );
+    const html = await res.text();
+
+    expect(html).toContain('providers="google,twitch,patreon"');
+  });
+
+  it("respects an author-specified providers attribute and doesn't override it", async () => {
+    const res = await injectPowerStrip(
+      htmlResponse('<html><body><power-strip providers="google"></power-strip></body></html>'),
+      USERS_PATH,
+      PROVIDERS,
+    );
+    const html = await res.text();
+
+    expect(html).toContain('providers="google"');
+    expect(html).not.toContain('providers="google,twitch,patreon"');
+    expect(html).not.toContain(DEFAULT_STRIP_STYLE);
+  });
+
+  it('detects the self-closing-style <power-strip/> the same way', async () => {
+    const res = await injectPowerStrip(
+      htmlResponse('<html><body><power-strip/></body></html>'),
+      USERS_PATH,
+      PROVIDERS,
+    );
+    const html = await res.text();
+
+    expect(html).toContain(`<script src="${USERS_PATH}power-strip.js" async></script>`);
+    expect(html).not.toContain(DEFAULT_STRIP_STYLE);
+    expect(html).toContain('providers="google,twitch,patreon"');
+  });
+
+  it('preserves the hidden attribute for the script-only opt-out', async () => {
+    const res = await injectPowerStrip(
+      htmlResponse('<html><body><power-strip hidden></power-strip></body></html>'),
+      USERS_PATH,
+      PROVIDERS,
+    );
+    const html = await res.text();
+
+    expect(html).toContain('hidden');
+    expect(html).not.toContain(DEFAULT_STRIP_STYLE);
+    expect(countPowerStrips(html)).toBe(1);
+  });
+
+  it('passes non-HTML responses through untouched', async () => {
+    const original = new Response('{"ok":true}', { headers: { 'Content-Type': 'application/json' } });
+    const res = await injectPowerStrip(original, USERS_PATH, PROVIDERS);
+
+    expect(res).toBe(original);
+    expect(await res.text()).toBe('{"ok":true}');
+  });
+});


### PR DESCRIPTION
## Problem

The worker injects a `<power-strip>` pinned to `position: absolute; top: 0; right: 0; z-index: 9999` on every proxied HTML page. This overlaps an author's own menu/header, and there is no way to move it. (Started from the question: *"is there any way to customize the power strip so it does not overlap my menu?"*)

## Solution

Let the page author place their own `<power-strip>` element anywhere in their HTML. When the worker sees one, it injects **only** `power-strip.js` (which defines the custom element) and leaves the author's element exactly where they put it — full control over placement and styling. When no element is present, behavior is unchanged (default top-right strip). Backward compatible.

Three behaviors, with the author element as the single control surface:

| Author markup | Result |
|---|---|
| *(none)* | Script + default top-right strip *(unchanged)* |
| `<power-strip>` anywhere | Script only; element left in place |
| `<power-strip hidden>` | Script only; no visible widget (JS API still available) |

## Implementation notes

- **Streaming detection.** At the `<body>` start tag, `HTMLRewriter` hasn't yet seen a `<power-strip>` that appears later in the body. We set a flag in a `power-strip` element handler and defer the default-strip decision to `element.onEndTag()` on `<body>`, by which point any author element has been parsed.
- **Providers auto-fill.** A bare `<power-strip>` gets the active `providers` attribute filled in so login buttons work out of the box; an author-set value (even `""`) is respected.
- **`hidden` opt-out.** Added `:host([hidden]) { display: none !important }` to `power-strip.js` — the existing `:host { display: block }` was overriding the UA `[hidden]` rule.
- **All spellings detected.** `<power-strip>`, `<power-strip></power-strip>`, and `<power-strip/>` all fire the element handler on the start tag, so no extra code was needed for the self-closing form. (Docs note that `<power-strip/>` isn't truly self-closing per the HTML spec — prefer an explicit closing tag.)
- Static SSR/asset pages (`profile.html`, `accounts.html`, `admin/index.html`) don't pass through `injectPowerStrip`, so no double-injection risk; they already hand-write the element.

## Testing

- New `test/powerstrip.spec.ts` (7 tests) unit-tests `injectPowerStrip` across all forms: default injection, author element → script-only, providers auto-fill, author providers respected, self-closing `<power-strip/>`, `hidden` opt-out, non-HTML passthrough.
- Full suite: **108/108 pass** (19 files). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
