### PR TITLE
Release v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "startup-api-cloudflare",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "startup-api-cloudflare",
-      "version": "0.0.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "prettier": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@startup-api/cloudflare",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Bumps the package version `0.1.0` → `0.2.0` in preparation for the `v0.2.0` GitHub Release, which triggers `publish.yml` to publish `@startup-api/cloudflare@0.2.0` to npm (Trusted Publishing / OIDC).

## What's in this release (since v0.1.0)

- **Customizable power-strip placement** (#99) — authors can place their own `<power-strip>` element to control its position/styling; the worker then injects only `power-strip.js`. Supports `providers` auto-fill and a `hidden` script-only opt-out.
- **Bypass access-policy gate for admin users** (#98)
- **CI:** Trusted Publishing via OIDC (#95) and GitHub Actions upgrades (#96)

After merge, the `v0.2.0` tag + GitHub Release will be created against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
