### PR TITLE
Add config-driven 'gate' page handling to access policy (#460)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,34 @@ Configure an ordered list of rules (first match wins) mapping a path pattern to 
 - **`authenticated`** — any logged-in user.
 - **`entitlement`** — a provider condition: Patreon `active_patron`, a specific `benefit` (perk) ID, or a `tier` ID.
 
-Patterns are exact (`/special`), prefix (`/app/*`), or `/` (homepage only). Each rule's `on_unauthorized` is `login` (redirect to sign in), `forbidden` (403), or `upgrade` (redirect to `upgrade_url`, e.g. a Patreon join page). When no policy is configured at all, every path is treated as `public` (backward compatible).
+Patterns are exact (`/special`), prefix (`/app/*`), or `/` (homepage only). Each rule's `on_unauthorized` is `login` (redirect to sign in), `forbidden` (403), `upgrade` (redirect to `upgrade_url`, e.g. a Patreon join page), or `gate` (serve an explainer page **in place**, with no redirect — see below). When no policy is configured at all, every path is treated as `public` (backward compatible).
+
+#### Serving a gate page in place (`on_unauthorized: 'gate'`)
+
+Instead of redirecting, a denied request can serve an explainer page **at the requested URL** (no redirect, status `200` by default). The page shown depends on login state, so anonymous and logged-in-but-unentitled visitors can see different copy:
+
+- **`anonymous`** (required) — shown to visitors who are **not** logged in (e.g. a "become a patron + log in" page).
+- **`unentitled`** (optional) — shown to logged-in visitors who fail the requirement (e.g. a "pledge/upgrade" page). Falls back to `anonymous` when omitted.
+- **`status`** (optional) — HTTP status for the served page; defaults to `200` to preserve typical explainer-page UX (set `403` if you prefer).
+
+Each variant is a `PageSource` whose body comes from **either** the `ASSETS` binding **or** a path proxied from `ORIGIN_URL` — exactly one of:
+
+- **`{ asset: '/early-access' }`** — a local file from `ASSETS` (resolved like other assets, `/early-access` → `early-access.html`).
+- **`{ origin: '/early-access' }`** — a path proxied from `ORIGIN_URL`. The path must be reachable directly on the origin (the raw site, not behind this worker).
+
+The gate config is set per rule via `gate`, or on the policy default via `default_gate`. The served gate page is produced inside the deny path, so it is not re-subjected to the access policy and no power-strip is injected — the page is expected to carry its own login CTA. Because nothing redirects, there is no loop risk.
+
+```ts
+const accessPolicy = {
+  default: { mode: 'entitlement', provider: 'patreon', condition: { type: 'benefit', benefit_id: '<BENEFIT_ID>' } },
+  default_on_unauthorized: 'gate',
+  default_gate: {
+    anonymous: { origin: '/early-access' }, // or { asset: '/early-access' }
+    unentitled: { origin: '/pledge-needed' }, // or { asset: '/pledge-needed' }
+    // status: 403, // optional; defaults to 200
+  },
+};
+```
 
 Admin users (those listed in `ADMIN_IDS`) bypass every `authenticated`/`entitlement` requirement and can reach any gated path. Their identity is still resolved and the usual identity/entitlement headers are forwarded to the origin — only the gate itself is skipped. (`bypass` paths remain a raw pass-through for everyone, with no identity resolution.)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "startup-api-cloudflare",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "startup-api-cloudflare",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "prettier": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@startup-api/cloudflare",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/src/createStartupAPI.ts
+++ b/src/createStartupAPI.ts
@@ -24,7 +24,7 @@ import { handleSSR } from './handlers/ssr';
 import type { StartupAPIEnv } from './StartupAPIEnv';
 import { StartupAPIConfigSchema } from './schemas/config';
 import type { StartupAPIConfig, ProviderOptions, ResolvedFreshness } from './schemas/config';
-import type { AccessPolicyConfig } from './schemas/policy';
+import type { AccessPolicyConfig, PageSource } from './schemas/policy';
 import { AccessPolicy, evaluateAccess } from './policy/accessPolicy';
 import type { PolicyDecision } from './policy/accessPolicy';
 import { loadEntitlements, entitlementHeaders } from './entitlements/service';
@@ -67,11 +67,46 @@ function resolveAccessPolicy(configPolicy: AccessPolicyConfig | undefined): Acce
   return configPolicy ?? { default: { mode: 'public' } };
 }
 
-/** Build a deny response (login redirect / 403 / upgrade redirect) for an unmet access requirement. */
+/**
+ * Serve a gate page body in place (no redirect), sourced from either the ASSETS binding (a local file)
+ * or a path proxied from ORIGIN_URL. The configured status is re-stamped onto the response so e.g. a
+ * 200 asset can be served as a 403 gate.
+ */
+async function serveGatePage(
+  source: PageSource,
+  status: number,
+  request: Request,
+  env: StartupAPIEnv,
+  reqUrl: URL,
+): Promise<Response> {
+  let res: Response;
+  if ('asset' in source) {
+    // Serve a local file from ASSETS, mirroring the existing user-asset path.
+    const assetReq = new Request(new URL(source.asset, reqUrl).toString(), { method: 'GET' });
+    assetReq.headers.set('x-skip-worker', 'true');
+    res = await env.ASSETS.fetch(assetReq);
+  } else {
+    // Proxy a path from ORIGIN_URL (swap host, set Host), like the main origin proxy.
+    const target = new URL(source.origin, new URL(env.ORIGIN_URL));
+    const proxied = new Request(target.toString(), request);
+    proxied.headers.set('Host', target.host);
+    res = await originFetch(proxied);
+  }
+  // Re-stamp the status (e.g. a 200 asset can be served as the configured gate status).
+  return new Response(res.body, { status, headers: res.headers });
+}
+
+/** Build a deny response (login redirect / 403 / upgrade redirect / in-place gate page) for an unmet access requirement. */
 function denyResponse(
   decision: Extract<PolicyDecision, { allow: false }>,
-  ctx: { usersPath: string; returnUrl: string; activeProviders: string[] },
-): Response {
+  ctx: { usersPath: string; returnUrl: string; activeProviders: string[]; authenticated: boolean; request: Request; env: StartupAPIEnv; url: URL },
+): Response | Promise<Response> {
+  if (decision.action === 'gate' && decision.gate) {
+    // Serve an explainer page in place: anonymous variant for logged-out visitors, unentitled variant
+    // (falling back to anonymous) for logged-in visitors who fail the requirement. No redirect.
+    const source = ctx.authenticated ? (decision.gate.unentitled ?? decision.gate.anonymous) : decision.gate.anonymous;
+    return serveGatePage(source, decision.gate.status ?? 200, ctx.request, ctx.env, ctx.url);
+  }
   if (decision.action === 'forbidden') {
     return new Response('Forbidden', { status: 403 });
   }
@@ -298,7 +333,15 @@ export function createStartupAPI(config: StartupAPIConfig = {}) {
       // Enforce the requirement. Admins bypass the gate (identity/headers above still apply).
       const decision = evaluateAccess(rule, { authenticated, entitlements, isAdmin: userIsAdmin });
       if (!decision.allow) {
-        return denyResponse(decision, { usersPath, returnUrl, activeProviders: getActiveProviders(env) });
+        return denyResponse(decision, {
+          usersPath,
+          returnUrl,
+          activeProviders: getActiveProviders(env),
+          authenticated,
+          request,
+          env,
+          url,
+        });
       }
 
       const response = await originFetch(newRequest);

--- a/src/policy/accessPolicy.ts
+++ b/src/policy/accessPolicy.ts
@@ -1,5 +1,5 @@
 import { AccessPolicySchema } from '../schemas/policy';
-import type { AccessPolicyConfig, AccessPolicyResolved, AccessRule, Requirement, UnauthorizedAction } from '../schemas/policy';
+import type { AccessPolicyConfig, AccessPolicyResolved, AccessRule, Gate, Requirement, UnauthorizedAction } from '../schemas/policy';
 import type { Entitlements } from '../entitlements/types';
 import { providerEntitlementCheckers, providerSupportsEntitlements } from './entitlementCheckers';
 
@@ -20,10 +20,10 @@ export function matchPattern(pattern: string, path: string): boolean {
 
 export type PolicyDecision =
   | { allow: true }
-  | { allow: false; reason: 'unauthenticated' | 'not_entitled'; action: UnauthorizedAction; upgrade_url?: string };
+  | { allow: false; reason: 'unauthenticated' | 'not_entitled'; action: UnauthorizedAction; upgrade_url?: string; gate?: Gate };
 
 function deny(reason: 'unauthenticated' | 'not_entitled', rule: AccessRule): PolicyDecision {
-  return { allow: false, reason, action: rule.on_unauthorized, upgrade_url: rule.upgrade_url };
+  return { allow: false, reason, action: rule.on_unauthorized, upgrade_url: rule.upgrade_url, gate: rule.gate };
 }
 
 /**
@@ -101,6 +101,7 @@ export class AccessPolicy {
       requirement: cfg.default ?? { mode: 'authenticated' },
       on_unauthorized: cfg.default_on_unauthorized,
       upgrade_url: cfg.default_upgrade_url,
+      gate: cfg.default_gate,
     };
   }
 }

--- a/src/schemas/policy.ts
+++ b/src/schemas/policy.ts
@@ -34,7 +34,27 @@ export const RequirementSchema = z.discriminatedUnion('mode', [
   }),
 ]);
 
-export const UnauthorizedActionSchema = z.enum(['login', 'forbidden', 'upgrade']);
+/** Where a gate page body comes from. Exactly one of asset/origin. */
+export const PageSourceSchema = z.union([
+  // Served from the ASSETS binding; path is resolved like other assets (`/foo` -> foo.html).
+  z.object({ asset: z.string() }),
+  // Proxied from this path on ORIGIN_URL.
+  z.object({ origin: z.string() }),
+]);
+export type PageSource = z.infer<typeof PageSourceSchema>;
+
+/** Page(s) served in place when a requirement is not met (on_unauthorized: 'gate'). */
+export const GateSchema = z.object({
+  /** Shown to visitors who are NOT logged in. Required. */
+  anonymous: PageSourceSchema,
+  /** Shown to logged-in visitors who fail the requirement. Falls back to `anonymous` if omitted. */
+  unentitled: PageSourceSchema.optional(),
+  /** HTTP status for the served page. Default 200 (preserves typical explainer-page UX). */
+  status: z.number().int().optional(),
+});
+export type Gate = z.infer<typeof GateSchema>;
+
+export const UnauthorizedActionSchema = z.enum(['login', 'forbidden', 'upgrade', 'gate']);
 
 export const RuleSchema = z.object({
   /** Path pattern: exact (`/special`), prefix (`/special/*`), or `/` for the homepage only. */
@@ -44,6 +64,8 @@ export const RuleSchema = z.object({
   on_unauthorized: UnauthorizedActionSchema.default('login'),
   /** Redirect target for the 'upgrade' action (e.g. a Patreon join page). */
   upgrade_url: z.string().optional(),
+  /** Page(s) served in place for the 'gate' action. */
+  gate: GateSchema.optional(),
 });
 
 export const AccessPolicySchema = z.object({
@@ -52,6 +74,8 @@ export const AccessPolicySchema = z.object({
   default: RequirementSchema.optional(),
   default_on_unauthorized: UnauthorizedActionSchema.default('login'),
   default_upgrade_url: z.string().optional(),
+  /** Page(s) served in place for the 'gate' action on paths that match no rule. */
+  default_gate: GateSchema.optional(),
 });
 
 export type EntitlementCondition = z.infer<typeof EntitlementConditionSchema>;

--- a/test/gate.spec.ts
+++ b/test/gate.spec.ts
@@ -1,0 +1,173 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { CookieManager } from '../src/CookieManager';
+import { createStartupAPI } from '../src/createStartupAPI';
+import { AccessPolicy } from '../src/policy/accessPolicy';
+import type { Gate } from '../src/schemas/policy';
+
+const cookieManager = new CookieManager(env.SESSION_SECRET);
+
+// Reset the global policy so each configured instance re-initializes, and leave it uninitialized
+// afterwards so other test files re-init from their own config.
+beforeEach(() => AccessPolicy.reset());
+afterAll(() => AccessPolicy.reset());
+
+// A path gated behind the "benefit-vip" Patreon perk. Denials are served as in-place gate pages.
+function gatePolicy(gate: Gate, on_unauthorized: 'gate' | 'upgrade' | 'login' = 'gate', extra: Record<string, unknown> = {}) {
+  return {
+    rules: [
+      {
+        pattern: '/gated',
+        requirement: { mode: 'entitlement' as const, provider: 'patreon', condition: { type: 'benefit' as const, benefit_id: 'benefit-vip' } },
+        on_unauthorized,
+        ...(on_unauthorized === 'gate' ? { gate } : {}),
+        ...extra,
+      },
+    ],
+    default: { mode: 'public' as const },
+  };
+}
+
+function fetchWith(policy: any, path: string, cookie?: string, assetsMock?: (req: Request) => Promise<Response>) {
+  const api = createStartupAPI({ accessPolicy: policy });
+  const ctx = createExecutionContext();
+  const headers: Record<string, string> = cookie ? { Cookie: `session_id=${cookie}` } : {};
+  // Override ASSETS only when a mock is provided (asset-sourced gate pages).
+  const testEnv = assetsMock ? { ...env, ASSETS: { fetch: vi.fn(assetsMock) } } : env;
+  return api.fetch(new Request('http://example.com' + path, { headers }), testEnv as any, ctx).then(async (res) => {
+    await waitOnExecutionContext(ctx);
+    return res;
+  });
+}
+
+// Logged-in Patreon user with the given benefits, stored entitlements seeded so no network is needed.
+async function createPatreonUser(benefits: string[], active = true, userId = env.USER.newUniqueId()) {
+  const userStub = env.USER.get(userId);
+  const userIdStr = userId.toString();
+  const subjectId = 'patreon-' + userIdStr.slice(0, 10);
+
+  await userStub.addMembership(env.ACCOUNT.newUniqueId().toString(), 1, true);
+  await userStub.addCredential('patreon', subjectId);
+  const { sessionId } = await userStub.createSession({ provider: 'patreon' });
+
+  const entitlements = {
+    provider: 'patreon',
+    checked_at: Date.now(),
+    source: 'oauth',
+    patreon: {
+      patron_status: active ? 'active_patron' : 'former_patron',
+      is_active_patron: active,
+      entitled_tier_ids: ['t1'],
+      entitled_benefit_ids: benefits,
+      pledge_amount_cents: 500,
+    },
+  };
+  await userStub.setEntitlements('patreon', subjectId, entitlements, entitlements.checked_at);
+
+  return cookieManager.encrypt(`${sessionId}:${userIdStr}`);
+}
+
+// Spy globalThis.fetch (origin proxy). Returns a distinct body per origin path so we can assert which
+// page was served.
+function spyOrigin() {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    const path = new URL(url).pathname;
+    return new Response(`origin:${path}`, { status: 200, headers: { 'Content-Type': 'text/html' } }) as any;
+  });
+}
+
+// ASSETS mock that returns a distinct body per asset path.
+async function assetMock(req: Request): Promise<Response> {
+  const path = new URL(req.url).pathname;
+  return new Response(`asset:${path}`, { status: 200, headers: { 'Content-Type': 'text/html' } });
+}
+
+describe('gate action — serves an explainer page in place', () => {
+  it('anonymous visitor → asset variant', async () => {
+    const gate: Gate = { anonymous: { asset: '/early-access' } };
+    const res = await fetchWith(gatePolicy(gate), '/gated', undefined, assetMock);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('asset:/early-access');
+  });
+
+  it('anonymous visitor → origin variant (no redirect)', async () => {
+    const gate: Gate = { anonymous: { origin: '/early-access' } };
+    const fetchSpy = spyOrigin();
+    try {
+      const res = await fetchWith(gatePolicy(gate), '/gated');
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('origin:/early-access');
+      // It is served in place — no redirect.
+      expect(res.headers.has('Location')).toBe(false);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('unentitled (logged-in, lacks benefit) → asset variant', async () => {
+    const gate: Gate = { anonymous: { asset: '/early-access' }, unentitled: { asset: '/pledge-needed' } };
+    const cookie = await createPatreonUser(['some-other-benefit']);
+    const res = await fetchWith(gatePolicy(gate), '/gated', cookie, assetMock);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('asset:/pledge-needed');
+  });
+
+  it('unentitled (logged-in, lacks benefit) → origin variant', async () => {
+    const gate: Gate = { anonymous: { origin: '/early-access' }, unentitled: { origin: '/pledge-needed' } };
+    const cookie = await createPatreonUser(['some-other-benefit']);
+    const fetchSpy = spyOrigin();
+    try {
+      const res = await fetchWith(gatePolicy(gate), '/gated', cookie);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('origin:/pledge-needed');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('unentitled falls back to anonymous when no unentitled variant is configured', async () => {
+    const gate: Gate = { anonymous: { asset: '/early-access' } };
+    const cookie = await createPatreonUser(['some-other-benefit']);
+    const res = await fetchWith(gatePolicy(gate), '/gated', cookie, assetMock);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('asset:/early-access');
+  });
+
+  it('re-stamps a custom status onto the served page', async () => {
+    const gate: Gate = { anonymous: { asset: '/early-access' }, status: 403 };
+    const res = await fetchWith(gatePolicy(gate), '/gated', undefined, assetMock);
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('asset:/early-access');
+  });
+
+  it('allows the gated path (no gate page) when the user has the required benefit', async () => {
+    const gate: Gate = { anonymous: { asset: '/early-access' } };
+    const cookie = await createPatreonUser(['benefit-vip']);
+    const fetchSpy = spyOrigin();
+    try {
+      const res = await fetchWith(gatePolicy(gate), '/gated', cookie);
+      expect(res.status).toBe(200);
+      // Served from origin (the real page), not the gate asset.
+      expect(await res.text()).toContain('origin:/gated');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+describe('gate action — back-compat: omitting gate leaves upgrade/login unchanged', () => {
+  it('upgrade still redirects (302) to upgrade_url', async () => {
+    const policy = gatePolicy({ anonymous: { asset: '/x' } }, 'upgrade', { upgrade_url: 'https://patreon.com/join' });
+    const res = await fetchWith(policy, '/gated');
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('https://patreon.com/join');
+  });
+
+  it('login still redirects (302) to authenticate', async () => {
+    const policy = gatePolicy({ anonymous: { asset: '/x' } }, 'login');
+    const res = await fetchWith(policy, '/gated');
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toContain('return_url=');
+  });
+});


### PR DESCRIPTION
## What

Adds a new `on_unauthorized: 'gate'` action so a denied request can serve an **explainer page in place** — in the response to the requested URL, with **no redirect** — instead of only redirecting to a single `upgrade_url`.

The page varies by login state and each variant's body is sourced from **either** the `ASSETS` binding (a local file) **or** a path proxied from `ORIGIN_URL`:

- **`anonymous`** (required) — shown to logged-out visitors (e.g. "become a patron + log in").
- **`unentitled`** (optional) — shown to logged-in visitors who fail the requirement (e.g. "pledge/upgrade"). Falls back to `anonymous` when omitted.
- **`status`** (optional) — HTTP status for the served page; defaults to `200`.

This lets consumer projects (e.g. drawleather.com) delete hand-written worker wrappers and keep only configuration.

## Changes

- **`src/schemas/policy.ts`** — new `PageSourceSchema` (`{ asset }` | `{ origin }`) and `GateSchema`; `'gate'` added to `UnauthorizedActionSchema`; `gate` on `RuleSchema` and `default_gate` on `AccessPolicySchema`. All optional → **non-breaking**.
- **`src/policy/accessPolicy.ts`** — `PolicyDecision` carries `gate`; `deny()` and the synthesized default rule thread it through (mirrors `upgrade_url`).
- **`src/createStartupAPI.ts`** — new `serveGatePage()` helper (ASSETS or origin-proxy, re-stamps status); `denyResponse()` serves the gate page before existing `forbidden`/`upgrade`/`login` handling, which is unchanged.
- **README** — documents the `gate` action, `gate`/`default_gate`, and `PageSource`.
- **Version** bumped `0.2.0` → `0.3.0`.

## Notes / decisions

- No power-strip injection on gate pages — the explainer page carries its own login CTA.
- No loop risk — serving in place issues no redirect; an `origin`-sourced gate path must be reachable on the raw origin.
- The gate response is produced inside the deny path, so it is not re-subjected to the access policy.

## Tests

New `test/gate.spec.ts` covers: anonymous→asset, anonymous→origin, unentitled→asset, unentitled→origin, `unentitled` falling back to `anonymous`, custom `status`, allow path (has benefit), and that omitting `gate` leaves `upgrade`/`login` behavior unchanged. Full suite: **119 passing**, lint clean.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)
