### PR TITLE
Release v0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "startup-api-cloudflare",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "startup-api-cloudflare",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "prettier": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@startup-api/cloudflare",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Patch release to refresh the README on the npm package page.

No code changes — bumps `@startup-api/cloudflare` to `0.3.2` so the updated install docs (the `npm create startup-api` scaffolder and automated-deployment guidance from #104) are published to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
