### PR TITLE
Fix: form-action CSP blocked atproto login form submission (v0.4.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@startup-api/cloudflare",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@startup-api/cloudflare",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "he": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@startup-api/cloudflare",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/src/auth/AtprotoProvider.ts
+++ b/src/auth/AtprotoProvider.ts
@@ -304,10 +304,12 @@ export class AtprotoProvider extends OAuthProvider {
       status,
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
-        // Same hardening as the auth error page: only same-origin styles/form, never framed, never cached
-        // (the re-rendered form reflects the user-supplied handle).
-        'Content-Security-Policy':
-          "default-src 'none'; style-src 'self' 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+        // Hardening: same-origin styles only, never framed, never cached (the form reflects the
+        // user-supplied handle). NOTE: deliberately NO `form-action` directive — submitting this form
+        // hits our endpoint, which 302-redirects to the user's *own* authorization server (any PDS).
+        // `form-action` is enforced across the whole redirect chain, so `'self'` (or any fixed list)
+        // would block that cross-origin redirect and the login would silently fail.
+        'Content-Security-Policy': "default-src 'none'; style-src 'self' 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'",
         'X-Content-Type-Options': 'nosniff',
         'Referrer-Policy': 'no-referrer',
         'Cache-Control': 'no-store',

--- a/test/atproto.spec.ts
+++ b/test/atproto.spec.ts
@@ -101,6 +101,9 @@ describe('atproto provider', () => {
     // Auth page hardening: not framable, not cached (it can reflect the user's handle).
     expect(res.headers.get('Content-Security-Policy')).toContain("frame-ancestors 'none'");
     expect(res.headers.get('Cache-Control')).toBe('no-store');
+    // Must NOT set form-action: submitting this form 302-redirects to the user's own auth server
+    // (any PDS), and form-action is enforced across the redirect chain — restricting it breaks login.
+    expect(res.headers.get('Content-Security-Policy')).not.toContain('form-action');
     const html = await res.text();
     expect(html).toContain('name="handle"');
   });


### PR DESCRIPTION
## Regression in 0.4.1 — atproto login form does nothing

The hardened CSP added to the handle-entry form in #106 included `form-action 'self'`, which **silently breaks login**.

### Root cause
Submitting the handle form hits our `/users/auth/atproto?handle=…` endpoint, which immediately **302-redirects to the user's own authorization server** (any PDS — `bsky.social` or self-hosted, cross-origin). `form-action` is enforced across the **entire redirect chain**, so `'self'` rejects the submission and the browser does nothing.

This is exactly the reported symptom: navigating to the auth URL **directly** works (no form involved), but the **form "doesn't send you there."**

Reproduced in headless Chrome — the console shows:

    Sending form data to '.../users/auth/atproto?handle=sergeyche.dev&return_url=%2F'
    violates the following Content Security Policy directive: "form-action 'self'". The request has been blocked.

### Fix
Remove the `form-action` directive from the handle form. It's fundamentally incompatible with a login form that must redirect to per-user auth servers. All other hardening stays: `default-src 'none'` (no scripts), `frame-ancestors 'none'`, `style-src 'self'`, `nosniff`, `no-store`. Added a regression test asserting the form CSP never carries `form-action`.

### Verified
- Drove the **fixed** form in headless Chrome against `wrangler dev`: submission now navigates to the auth endpoint with the handle and no CSP violation (localhost returns 400 only because bsky can't fetch a `127.0.0.1` client-metadata URL for PAR; on the live HTTPS demo it 302s to bsky).
- `tsc` + `eslint` clean; full suite **129/129**.

Bumps patch version to **0.4.2** (0.4.1 is live-broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
