### PR TITLE
Emphasize atproto handle (@ + larger font) (v0.4.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@startup-api/cloudflare",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@startup-api/cloudflare",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "he": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@startup-api/cloudflare",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/public/users/profile.html
+++ b/public/users/profile.html
@@ -451,7 +451,8 @@
       }
       function credentialIdentifier(c) {
         if (c.provider === 'atproto') {
-          return c.handle ? `${c.handle} (${c.subject_id})` : c.subject_id;
+          if (!c.handle) return c.subject_id;
+          return `<span style="font-size: 1.05rem; font-weight: 600;">@${c.handle}</span> <span style="opacity: 0.6;">(${c.subject_id})</span>`;
         }
         return c.email || c.subject_id;
       }

--- a/src/handlers/ssr.ts
+++ b/src/handlers/ssr.ts
@@ -214,10 +214,14 @@ function providerLabel(provider: string): string {
   return provider.charAt(0).toUpperCase() + provider.slice(1);
 }
 
-/** The identifier shown under the provider name. atproto shows the handle with the DID in parens. */
+/**
+ * The identifier shown under the provider name. atproto emphasizes the handle (larger, with an `@`)
+ * and de-emphasizes the DID in parentheses.
+ */
 function credentialIdentifier(c: any): string {
   if (c.provider === 'atproto') {
-    return c.handle ? `${c.handle} (${c.subject_id})` : c.subject_id;
+    if (!c.handle) return c.subject_id;
+    return `<span style="font-size: 1.05rem; font-weight: 600;">@${c.handle}</span> <span style="opacity: 0.6;">(${c.subject_id})</span>`;
   }
   return c.email || c.subject_id;
 }

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -344,9 +344,10 @@ describe('Integration Tests', () => {
     expect(html).toContain('twitch@example.com');
     expect(html).toContain('providers="google,twitch,patreon"');
     expect(html).not.toContain('{{ssr:profile_name}}');
-    // atproto credential: branded label + "handle (did)" identifier, not the bare provider key.
+    // atproto credential: branded label + "@handle (did)" identifier, not the bare provider key.
     expect(html).toContain('Atmosphere / ATproto');
-    expect(html).toContain('tester.bsky.social (did:plc:abc123)');
+    expect(html).toContain('@tester.bsky.social');
+    expect(html).toContain('(did:plc:abc123)');
     // The old Bluesky butterfly mark must not appear anywhere on the rendered page (SSR or client script).
     expect(html).not.toContain('M12 10.5C10.9');
   });


### PR DESCRIPTION
## Emphasize the atproto handle in the Login Credentials list

Per request: show the handle with an **`@`** prefix and in a **larger, bold font** so it stands out, with the DID de-emphasized in parentheses.

Before: `sergeyche.dev (did:plc:…)`
After: **@sergeyche.dev**  (did:plc:…)  — handle at 1.05rem/600, DID dimmed.

Applied to both the server (`ssr.ts`) and client (`profile.html`) renderers; other providers unchanged; bare-DID fallback retained for credentials with no stored handle. Integration assertions updated.

`tsc` + `eslint` clean; suite **129/129**. Bumps to **0.4.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
