### PR TITLE
Load power-strip.js as ES module (import.meta.url path detection) (v0.4.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@startup-api/cloudflare",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@startup-api/cloudflare",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "Apache-2.0",
       "dependencies": {
         "he": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@startup-api/cloudflare",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/public/users/accounts.html
+++ b/public/users/accounts.html
@@ -15,7 +15,7 @@
     <power-strip providers="{{ssr:providers}}" style="position: absolute; top: 0; right: 0; z-index: 9999; border-radius: 0 0 0 0.3rem">
       <svg viewBox="0 0 24 24" style="width: 1rem; height: 1rem"><path d="M7 2v11h3v9l7-12h-4l4-8z" fill="#ffcc00" /></svg>
     </power-strip>
-    <script src="/users/power-strip.js" async></script>
+    <script type="module" src="/users/power-strip.js" async></script>
 
     <div class="header-area">
       <a href="/" class="back-link">← Back to Home</a>

--- a/public/users/admin/index.html
+++ b/public/users/admin/index.html
@@ -181,7 +181,7 @@
     <power-strip providers="{{ssr:providers}}" style="position: absolute; top: 0; right: 0; z-index: 9999; border-radius: 0 0 0 0.3rem">
       <svg viewBox="0 0 24 24" style="width: 1rem; height: 1rem"><path d="M7 2v11h3v9l7-12h-4l4-8z" fill="#ffcc00" /></svg>
     </power-strip>
-    <script src="/users/power-strip.js" async></script>
+    <script type="module" src="/users/power-strip.js" async></script>
 
     <h1>StartupAPI Admin</h1>
 

--- a/public/users/power-strip.js
+++ b/public/users/power-strip.js
@@ -17,22 +17,15 @@ class PowerStrip extends HTMLElement {
   }
 
   detectBasePath() {
-    const script =
-      document.currentScript ||
-      (function () {
-        const scripts = document.getElementsByTagName('script');
-        return scripts[scripts.length - 1];
-      })();
-
-    if (script && script.src) {
-      try {
-        const url = new URL(script.src);
-        return url.pathname.substring(0, url.pathname.lastIndexOf('/'));
-      } catch (e) {
-        console.error('Failed to parse script URL', e);
-      }
+    // This file is loaded as an ES module (`<script type="module">`), so `document.currentScript`
+    // is null. `import.meta.url` is the module's own URL and is the reliable way to locate ourselves.
+    try {
+      const url = new URL(import.meta.url);
+      return url.pathname.substring(0, url.pathname.lastIndexOf('/'));
+    } catch (e) {
+      console.error('Failed to derive base path from import.meta.url', e);
+      return '';
     }
-    return '';
   }
 
   async connectedCallback() {

--- a/public/users/profile.html
+++ b/public/users/profile.html
@@ -10,7 +10,7 @@
     <power-strip providers="{{ssr:providers}}" style="position: absolute; top: 0; right: 0; z-index: 9999; border-radius: 0 0 0 0.3rem">
       <svg viewBox="0 0 24 24" style="width: 1rem; height: 1rem"><path d="M7 2v11h3v9l7-12h-4l4-8z" fill="#ffcc00" /></svg>
     </power-strip>
-    <script src="/users/power-strip.js" async></script>
+    <script type="module" src="/users/power-strip.js" async></script>
 
     <div class="header-area">
       <a href="/" class="back-link">← Back to Home</a>

--- a/src/PowerStrip.ts
+++ b/src/PowerStrip.ts
@@ -24,7 +24,7 @@ export async function injectPowerStrip(response: Response, usersPath: string, pr
         element(element) {
           // The script is always needed to define the <power-strip> custom element.
           // It is loaded from the USERS_PATH, which is intercepted by this worker.
-          element.prepend(`<script src="${usersPath}power-strip.js" async></script>`, { html: true });
+          element.prepend(`<script type="module" src="${usersPath}power-strip.js" async></script>`, { html: true });
 
           // Defer the component decision until the end of <body>, by which point
           // the streaming parser has seen any author-supplied <power-strip>.

--- a/test/manual/power-strip-theme.html
+++ b/test/manual/power-strip-theme.html
@@ -113,6 +113,6 @@
     </div>
 
     <!-- Loads the real component. Relative path resolves from test/manual/ to public/users/. -->
-    <script src="../../public/users/power-strip.js"></script>
+    <script type="module" src="../../public/users/power-strip.js"></script>
   </body>
 </html>

--- a/test/powerstrip.spec.ts
+++ b/test/powerstrip.spec.ts
@@ -21,7 +21,7 @@ describe('injectPowerStrip', () => {
     const res = await injectPowerStrip(htmlResponse('<html><body><h1>Hi</h1></body></html>'), USERS_PATH, PROVIDERS);
     const html = await res.text();
 
-    expect(html).toContain(`<script src="${USERS_PATH}power-strip.js" async></script>`);
+    expect(html).toContain(`<script type="module" src="${USERS_PATH}power-strip.js" async></script>`);
     expect(html).toContain(DEFAULT_STRIP_STYLE);
     expect(html).toContain('<power-strip providers="google,twitch,patreon"');
     expect(countPowerStrips(html)).toBe(1);
@@ -35,7 +35,7 @@ describe('injectPowerStrip', () => {
     );
     const html = await res.text();
 
-    expect(html).toContain(`<script src="${USERS_PATH}power-strip.js" async></script>`);
+    expect(html).toContain(`<script type="module" src="${USERS_PATH}power-strip.js" async></script>`);
     // No default strip appended, and the author's element is left in place.
     expect(html).not.toContain(DEFAULT_STRIP_STYLE);
     expect(countPowerStrips(html)).toBe(1);
@@ -74,7 +74,7 @@ describe('injectPowerStrip', () => {
     );
     const html = await res.text();
 
-    expect(html).toContain(`<script src="${USERS_PATH}power-strip.js" async></script>`);
+    expect(html).toContain(`<script type="module" src="${USERS_PATH}power-strip.js" async></script>`);
     expect(html).not.toContain(DEFAULT_STRIP_STYLE);
     expect(html).toContain('providers="google,twitch,patreon"');
   });


### PR DESCRIPTION
## Load power-strip.js as an ES module

Switches every `power-strip.js` injection to `<script type="module" async>` — the auto-injected tag (`PowerStrip.ts`), the internal pages (profile / accounts / admin), and the manual theme test.

### Path detection
Module scripts execute with `document.currentScript === null`, so the previous detection (currentScript + a last-`<script>` fallback) breaks. Replaced with **`import.meta.url`**, the module's own URL — the reliable way for the script to locate itself and derive `basePath`.

### Verified
- Real-browser check (headless Chrome against `wrangler dev`): the custom element upgrades, `basePath` resolves to `/users`, and there are **no console errors**.
- `power-strip.js` is module-safe: it uses `addEventListener` (no inline handlers), and its only global contract is `customElements.define`.
- `powerstrip.spec.ts` assertions updated to the new tag; `tsc` + `eslint` clean; suite **129/129**.

Bumps to **0.4.5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
